### PR TITLE
Record warning when nodejs not available DO NOT MERGE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <assertj.version>3.10.0</assertj.version>
         <junit.version>4.12</junit.version>
-        <sonar.version>7.2</sonar.version>
+        <sonar.version>7.4-alpha2</sonar.version>
         <sonar.min.version>6.7</sonar.min.version>
         <sonar-orchestrator.version>3.21.0.1721</sonar-orchestrator.version>
         <sonarlint.version>3.1.0.1376</sonarlint.version>

--- a/sonar-css-plugin/src/main/java/org/sonar/css/plugin/AnalysisWarningsWrapper.java
+++ b/sonar-css-plugin/src/main/java/org/sonar/css/plugin/AnalysisWarningsWrapper.java
@@ -1,0 +1,43 @@
+/*
+ * SonarCSS
+ * Copyright (C) 2018-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.css.plugin;
+
+import org.sonar.api.batch.InstantiationStrategy;
+import org.sonar.api.batch.ScannerSide;
+import org.sonar.api.notifications.AnalysisWarnings;
+
+/**
+ * Wrap an AnalysisWarnings instance, available since SQ API 7.4.
+ * Do not load this class on older runtimes.
+ * Drop this class when the minimum supported version of SonarQube API reaches 7.4.
+ */
+@ScannerSide
+@InstantiationStrategy("PER_BATCH")
+public class AnalysisWarningsWrapper {
+  private final AnalysisWarnings analysisWarnings;
+
+  public AnalysisWarningsWrapper(AnalysisWarnings analysisWarnings) {
+    this.analysisWarnings = analysisWarnings;
+  }
+
+  public void addUnique(String text) {
+    this.analysisWarnings.addUnique(text);
+  }
+}

--- a/sonar-css-plugin/src/main/java/org/sonar/css/plugin/CssPlugin.java
+++ b/sonar-css-plugin/src/main/java/org/sonar/css/plugin/CssPlugin.java
@@ -20,12 +20,16 @@
 package org.sonar.css.plugin;
 
 import org.sonar.api.Plugin;
+import org.sonar.api.SonarProduct;
+import org.sonar.api.SonarRuntime;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
 import org.sonar.api.utils.Version;
 import org.sonar.css.plugin.bundle.CssBundleHandler;
 
 public class CssPlugin implements Plugin {
+
+  private static final Version ANALYSIS_WARNINGS_MIN_SUPPORTED_SQ_VERSION = Version.create(7, 4);
 
   static final String FILE_SUFFIXES_KEY = "sonar.css.file.suffixes";
   public static final String FILE_SUFFIXES_DEFVALUE = ".css,.less,.scss";
@@ -86,5 +90,17 @@ public class CssPlugin implements Plugin {
           .multiValues(true)
           .build());
     }
+
+    if (isAnalysisWarningsSupported(context.getRuntime())) {
+      context.addExtension(AnalysisWarningsWrapper.class);
+    }
+  }
+
+  /**
+   * Drop this and related when the minimum supported version of SonarQube API reaches 7.4.
+   */
+  private static boolean isAnalysisWarningsSupported(SonarRuntime runtime) {
+    return runtime.getApiVersion().isGreaterThanOrEqual(ANALYSIS_WARNINGS_MIN_SUPPORTED_SQ_VERSION)
+      && runtime.getProduct() != SonarProduct.SONARLINT;
   }
 }

--- a/sonar-css-plugin/src/test/java/org/sonar/css/plugin/AnalysisWarningsWrapperTest.java
+++ b/sonar-css-plugin/src/test/java/org/sonar/css/plugin/AnalysisWarningsWrapperTest.java
@@ -1,0 +1,39 @@
+/*
+ * SonarCSS
+ * Copyright (C) 2018-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.css.plugin;
+
+import org.junit.Test;
+import org.sonar.api.notifications.AnalysisWarnings;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class AnalysisWarningsWrapperTest {
+  @Test
+  public void delegate_to_analysisWarnings() {
+    AnalysisWarnings analysisWarnings = mock(AnalysisWarnings.class);
+
+    AnalysisWarningsWrapper wrapper = new AnalysisWarningsWrapper(analysisWarnings);
+
+    String warning = "some warning";
+    wrapper.addUnique(warning);
+    verify(analysisWarnings).addUnique(warning);
+  }
+}

--- a/sonar-css-plugin/src/test/java/org/sonar/css/plugin/CssPluginTest.java
+++ b/sonar-css-plugin/src/test/java/org/sonar/css/plugin/CssPluginTest.java
@@ -47,4 +47,22 @@ public class CssPluginTest {
     underTest.define(context);
     assertThat(context.getExtensions()).hasSize(12);
   }
+
+  @Test
+  public void count_extensions_7_4() {
+    SonarRuntime runtime = SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SCANNER);
+    Plugin.Context context = new Plugin.Context(runtime);
+    Plugin underTest = new CssPlugin();
+    underTest.define(context);
+    assertThat(context.getExtensions()).hasSize(13);
+  }
+
+  @Test
+  public void count_extensions_7_4_sonarlint() {
+    SonarRuntime runtime = SonarRuntimeImpl.forSonarLint(Version.create(7, 4));
+    Plugin.Context context = new Plugin.Context(runtime);
+    Plugin underTest = new CssPlugin();
+    underTest.define(context);
+    assertThat(context.getExtensions()).hasSize(12);
+  }
 }


### PR DESCRIPTION
fixes #123 

Notes for manual testing, easy ways to trigger the 3 kinds of warnings:

- `sonar-scanner -Dsonar.css.node=/tmp` (not a file)
- `sonar-scanner -Dsonar.css.node=/tmp/old` where `/tmp/old` is a shell script with a simple `echo` of an unsupported old version, for example `echo v5.11.1`
- `sonar-scanner -Dsonar.css.node=/tmp/rubbish` where `/tmp/rubbish` is a shell script with a simple `echo rubbish`

### Implementation notes

This work depends on new features in the SonarQube API. It can be merged after the API changes are part of a milestone / stable release (ETA Sep 28).

**Update:** the new ETA is Oct 10.