### PR TITLE
Consider 'x' unit as compliant for S4653

### DIFF
--- a/its/plugin/projects/issues-project/src/file1.css
+++ b/its/plugin/projects/issues-project/src/file1.css
@@ -70,3 +70,9 @@ unknown {                                                     /* S4670 | selecto
 mat-form-field {                                              /* Angular Material, ignored by S4670 | selector-type-no-unknown */
   width: 100%;
 }
+
+div {
+  background-image: image-set(
+	  '/images/some-image-1x.jpg' 1x,                       /* 'x' is synonym to 'dppx', ignored by S4653 | unit-no-unknown */
+	);
+}

--- a/sonar-css-plugin/src/main/java/org/sonar/css/plugin/rules/UnitNoUnknown.java
+++ b/sonar-css-plugin/src/main/java/org/sonar/css/plugin/rules/UnitNoUnknown.java
@@ -19,6 +19,8 @@
  */
 package org.sonar.css.plugin.rules;
 
+import java.util.Arrays;
+import java.util.List;
 import org.sonar.check.Rule;
 
 @Rule(key = "S4653")
@@ -27,5 +29,15 @@ public class UnitNoUnknown implements CssRule {
   @Override
   public String stylelintKey() {
     return "unit-no-unknown";
+  }
+
+  @Override
+  public List<Object> stylelintOptions() {
+    return Arrays.asList(true, new StylelintIgnoreOption());
+  }
+
+  private static class StylelintIgnoreOption {
+    // Used by GSON serialization
+    private final String[] ignoreUnits = {"x"};
   }
 }

--- a/sonar-css-plugin/src/test/java/org/sonar/css/plugin/rules/CssRuleTest.java
+++ b/sonar-css-plugin/src/test/java/org/sonar/css/plugin/rules/CssRuleTest.java
@@ -46,7 +46,8 @@ public class CssRuleTest {
       DeclarationBlockNoDuplicateProperties.class,
       PropertyNoUnknown.class,
       SelectorPseudoClassNoUnknown.class,
-      SelectorTypeNoUnknown.class);
+      SelectorTypeNoUnknown.class,
+      UnitNoUnknown.class);
 
     for (Class ruleClass : CssRules.getRuleClasses()) {
       CssRule rule = (CssRule)ruleClass.getConstructor().newInstance();
@@ -74,6 +75,12 @@ public class CssRuleTest {
   public void selector_type_no_unknown_options() {
     String optionsAsJson = new Gson().toJson(new SelectorTypeNoUnknown().stylelintOptions());
     assertThat(optionsAsJson).isEqualTo("[true,{\"ignoreTypes\":[\"/^mat-/\"]}]");
+  }
+
+  @Test
+  public void units_no_unknown_options() {
+    String optionsAsJson = new Gson().toJson(new UnitNoUnknown().stylelintOptions());
+    assertThat(optionsAsJson).isEqualTo("[true,{\"ignoreUnits\":[\"x\"]}]");
   }
 
   @Test


### PR DESCRIPTION
fixes #139 