### PR TITLE
Exclude JS/TS from analysis

### DIFF
--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>its</artifactId>
     <groupId>org.sonarsource.css</groupId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/its/plugin/projects/issues-project/src/file7.jsx
+++ b/its/plugin/projects/issues-project/src/file7.jsx
@@ -1,0 +1,1 @@
+// file is not analyzed

--- a/its/plugin/src/test/java/org/sonar/css/its/IssuesTest.java
+++ b/its/plugin/src/test/java/org/sonar/css/its/IssuesTest.java
@@ -67,7 +67,7 @@ public class IssuesTest {
 
     assertThat(issuesList).extracting("rule").hasSize(
       CssRules.getRuleClasses().size() * 3 /* issues are raised against .css, .less and .scss */
-      + 2 /* for html and vue files */
+      + 1 /* for html file */
       + 1 /* issue S4654 is raised for comment */
       + 1 /* issue S4662 is raised for cssModules.css */
       - 2 /* issue S4668 not raised on .less nor .scss */);

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>css</artifactId>
     <groupId>org.sonarsource.css</groupId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.sonarsource.css</groupId>
     <artifactId>css</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>SonarCSS</name>

--- a/sonar-css-plugin/pom.xml
+++ b/sonar-css-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sonarsource.css</groupId>
         <artifactId>css</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sonar-css-plugin</artifactId>

--- a/sonar-css-plugin/src/main/java/org/sonar/css/plugin/StylelintCommandProvider.java
+++ b/sonar-css-plugin/src/main/java/org/sonar/css/plugin/StylelintCommandProvider.java
@@ -33,7 +33,7 @@ import org.sonarsource.nodejs.NodeCommand;
 public class StylelintCommandProvider implements LinterCommandProvider {
 
   private static final String CONFIG_PATH = "css-bundle/stylelintconfig.json";
-  private static final List<String> LANGUAGES_TO_ANALYZE = Arrays.asList("css", "html", "php", "javascript", "typescript");
+  private static final List<String> LANGUAGES_TO_ANALYZE = Arrays.asList("css", "html", "php");
 
   @Override
   public NodeCommand nodeCommand(File deployDestination, SensorContext context, Consumer<String> output, Consumer<String> error) {

--- a/sonar-css-plugin/src/test/java/org/sonar/css/plugin/StylelintCommandProviderTest.java
+++ b/sonar-css-plugin/src/test/java/org/sonar/css/plugin/StylelintCommandProviderTest.java
@@ -46,13 +46,14 @@ public class StylelintCommandProviderTest {
     SensorContextTester context = SensorContextTester.create(baseDir);
     context.settings().setProperty(CssPlugin.FILE_SUFFIXES_KEY, ".foo,.bar")
       .setProperty("sonar.javascript.file.suffixes", ".js")
+      .setProperty("sonar.php.file.suffixes", ".php")
       .setProperty("sonar.java.file.suffixes", ".java");
     Consumer<String> noop = a -> {};
     NodeCommand nodeCommand = stylelintCommandProvider.nodeCommand(deployDestination, context, noop, noop);
     assertThat(nodeCommand.toString()).endsWith(
       String.join(" ",
       new File(deployDestination, "css-bundle/node_modules/stylelint/bin/stylelint").getAbsolutePath(),
-      baseDir.getAbsolutePath() + File.separator + "**" + File.separator + "*{.foo,.bar,.js}",
+      baseDir.getAbsolutePath() + File.separator + "**" + File.separator + "*{.foo,.bar,.php}",
       "--config",
       new File(deployDestination, "css-bundle/stylelintconfig.json").getAbsolutePath(),
       "-f",


### PR DESCRIPTION
When analysing JSX or TSX files stylelint fails with
```
Error: Cannot find module 'postcss-jsx/extract'
```

This results in a error log:
```
ERROR: Analysis didn't terminate normally, please verify ERROR and WARN logs above. Exit code 1
```
Note that there is no `ERROR and WARN logs above`, as probably Stylelint prints the stacktrace into stdout (and we forward stderr only)
(see [this thread](https://community.sonarsource.com/t/error-analysis-didnt-terminate-normally-please-verify-error-and-warn-logs-above-exit-code-1/11307))

Before we understand why this happens we exclude JS and TS languages from analysis by stylelint.