### PR TITLE
S4662: Ignore Sass/SCSS `@use` at-rule (#252)

### DIFF
--- a/sonar-css-plugin/src/main/java/org/sonar/css/plugin/rules/AtRuleNoUnknown.java
+++ b/sonar-css-plugin/src/main/java/org/sonar/css/plugin/rules/AtRuleNoUnknown.java
@@ -29,7 +29,7 @@ import static org.sonar.css.plugin.rules.RuleUtils.splitAndTrim;
 @Rule(key = "S4662")
 public class AtRuleNoUnknown implements CssRule {
 
-  private static final String DEFAULT_IGNORED_AT_RULES = "value,at-root,content,debug,each,else,error,for,function,if,include,mixin,return,warn,while,extend";
+  private static final String DEFAULT_IGNORED_AT_RULES = "value,at-root,content,debug,each,else,error,for,function,if,include,mixin,return,warn,while,extend,use";
 
   @RuleProperty(
     key = "ignoreAtRules",

--- a/sonar-css-plugin/src/test/java/org/sonar/css/plugin/rules/CssRuleTest.java
+++ b/sonar-css-plugin/src/test/java/org/sonar/css/plugin/rules/CssRuleTest.java
@@ -109,7 +109,7 @@ public class CssRuleTest {
   @Test
   public void at_rule_unknown_default() {
     String optionsAsJson = new Gson().toJson(new AtRuleNoUnknown().stylelintOptions());
-    assertThat(optionsAsJson).isEqualTo("[true,{\"ignoreAtRules\":[\"value\",\"at-root\",\"content\",\"debug\",\"each\",\"else\",\"error\",\"for\",\"function\",\"if\",\"include\",\"mixin\",\"return\",\"warn\",\"while\",\"extend\"]}]");
+    assertThat(optionsAsJson).isEqualTo("[true,{\"ignoreAtRules\":[\"value\",\"at-root\",\"content\",\"debug\",\"each\",\"else\",\"error\",\"for\",\"function\",\"if\",\"include\",\"mixin\",\"return\",\"warn\",\"while\",\"extend\",\"use\"]}]");
   }
 
   @Test


### PR DESCRIPTION
Eliminate false-positives for the Sass/SCSS `@use` at-rule.