### PR TITLE
S4654: Ignore unknown properties inside :export and :import selectors

### DIFF
--- a/sonar-css-plugin/src/main/java/org/sonar/css/plugin/rules/PropertyNoUnknown.java
+++ b/sonar-css-plugin/src/main/java/org/sonar/css/plugin/rules/PropertyNoUnknown.java
@@ -39,6 +39,7 @@ public class PropertyNoUnknown implements CssRule {
 
   private static class StylelintIgnoreOption {
     // Used by GSON serialization
-    private final String[] ignoreProperties = {"composes", "exportedKey", "localAlias"};
+    private final String[] ignoreProperties = {"composes"};
+    private final String[] ignoreSelectors = {"export", "import"};
   }
 }

--- a/sonar-css-plugin/src/test/java/org/sonar/css/plugin/rules/CssRuleTest.java
+++ b/sonar-css-plugin/src/test/java/org/sonar/css/plugin/rules/CssRuleTest.java
@@ -69,7 +69,7 @@ public class CssRuleTest {
   @Test
   public void property_no_unknown_options() {
     String optionsAsJson = new Gson().toJson(new PropertyNoUnknown().stylelintOptions());
-    assertThat(optionsAsJson).isEqualTo("[true,{\"ignoreProperties\":[\"composes\",\"exportedKey\",\"localAlias\"]}]");
+    assertThat(optionsAsJson).isEqualTo("[true,{\"ignoreProperties\":[\"composes\"],\"ignoreSelectors\":[\"export\",\"import\"]}]");
   }
 
   @Test

--- a/sonar-css-plugin/src/test/java/org/sonar/css/plugin/server/CssAnalyzerBridgeServerTest.java
+++ b/sonar-css-plugin/src/test/java/org/sonar/css/plugin/server/CssAnalyzerBridgeServerTest.java
@@ -267,7 +267,7 @@ public class CssAnalyzerBridgeServerTest {
 
     @Override
     public String resolve(String relativePath) {
-      File file = new File("src/test/resources");
+      File file = new File("css-bundle");
       return new File(file.getAbsoluteFile(), relativePath).getAbsolutePath();
     }
   }


### PR DESCRIPTION
Avoid false-positive from custom properties inside :export and :import selectors
Remove sample ignore properties "exportedKey" and "localAlias"

Resolves #258