### PR TITLE
Remove log from isAlive check, it can be noisy when server is slow to start

### DIFF
--- a/sonar-css-plugin/src/main/java/org/sonar/css/plugin/server/CssAnalyzerBridgeServer.java
+++ b/sonar-css-plugin/src/main/java/org/sonar/css/plugin/server/CssAnalyzerBridgeServer.java
@@ -233,7 +233,6 @@ public class CssAnalyzerBridgeServer implements Startable {
       // in this case response.body() is never null (according to docs)
       return "OK!".equals(body);
     } catch (IOException e) {
-      LOG.warn("Error requesting server status. Server is probably dead.", e);
       return false;
     }
   }


### PR DESCRIPTION
Function `isAlive()` is used to check if the bridge is already started. This can take sometime on slower machine, so there will be too much noisy log printed in such case.

Negative results of `isAlive` is logged on the call site when really needed.