### PR TITLE
Ignore ::deep in blazor css files

### DIFF
--- a/its/sources/custom/S4660.scss
+++ b/its/sources/custom/S4660.scss
@@ -2,6 +2,10 @@
     min-width: 0;
 }
 
+& ::deep .q-tab__content {
+  min-width: 0;
+}
+
 ion-select::part(icon) {
   display: none;
 }

--- a/sonar-css-plugin/src/main/java/org/sonar/css/plugin/rules/SelectorPseudoElementNoUnknown.java
+++ b/sonar-css-plugin/src/main/java/org/sonar/css/plugin/rules/SelectorPseudoElementNoUnknown.java
@@ -29,7 +29,7 @@ import static org.sonar.css.plugin.rules.RuleUtils.splitAndTrim;
 @Rule(key = "S4660")
 public class SelectorPseudoElementNoUnknown implements CssRule {
 
-  private static final String DEFAULT_IGNORE_PSEUDO_ELEMENTS = "ng-deep,v-deep";
+  private static final String DEFAULT_IGNORE_PSEUDO_ELEMENTS = "ng-deep,v-deep,deep";
 
   @Override
   public String stylelintKey() {

--- a/sonar-css-plugin/src/test/java/org/sonar/css/plugin/rules/CssRuleTest.java
+++ b/sonar-css-plugin/src/test/java/org/sonar/css/plugin/rules/CssRuleTest.java
@@ -94,7 +94,7 @@ public class CssRuleTest {
   @Test
   public void selector_pseudo_element_no_unknown_default() {
     String optionsAsJson = new Gson().toJson(new SelectorPseudoElementNoUnknown().stylelintOptions());
-    assertThat(optionsAsJson).isEqualTo("[true,{\"ignorePseudoElements\":[\"ng-deep\",\"v-deep\"]}]");
+    assertThat(optionsAsJson).isEqualTo("[true,{\"ignorePseudoElements\":[\"ng-deep\",\"v-deep\",\"deep\"]}]");
   }
 
   @Test


### PR DESCRIPTION
Microsoft uses the ::deep combinator to apply css in child components. Like the Angular and Vue deep elements, this should also be ignored.

https://docs.microsoft.com/en-us/aspnet/core/blazor/components/css-isolation?view=aspnetcore-5.0#child-component-support