### PR TITLE
Use gz instead of xz in Dockerfile

### DIFF
--- a/.cirrus/nodejs-10.Dockerfile
+++ b/.cirrus/nodejs-10.Dockerfile
@@ -4,9 +4,9 @@ USER root
 
 ENV NODE_VERSION v10.23.2
 
-RUN  wget -U "nodejs" -q -O nodejs.tar.xz https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz \
-    && tar -xJf "nodejs.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-    && rm nodejs.tar.xz \
+RUN  wget -U "nodejs" -q -O nodejs.tar.gz https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz \
+    && tar -xzf "nodejs.tar.gz" -C /usr/local --strip-components=1 --no-same-owner \
+    && rm nodejs.tar.gz \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 ENV YARN_VERSION 1.22.5


### PR DESCRIPTION
The base image does not have the package `xz-utils` anymore, so without this change (re)build of this image fails with message

    tar (child): xz: Cannot exec: No such file or directory

Unlikely `gzip` package will disappear from the base image, also it is already used in this Dockerfile.